### PR TITLE
Added support for mapping objects & factories for specific requesting modules (or matchers for them) only. Unit tests now run on Windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ task :default => [:build]
 desc 'Create js files from coffee sources'
 task :build do
   system("cd #{root} && bundle exec coffee --compile --output . src/isolate.coffee")
+  system("cd #{root} && bundle exec coffee --compile --output ./node_modules src/isolate.coffee")
   system("cd #{root} && bundle exec coffee --compile spec")
 end
 
@@ -23,7 +24,7 @@ test_namespace = namespace :test do
     debug = isDebug?() ? ' debug' : ''
     supportedVersionsRegex = Regexp.new("^2\.[0-9]\.[0-9]$")
 
-    all_versions = `npm view requirejs versions | grep -oE [0-9.]+`.split
+    all_versions = `npm view requirejs versions`.scan(/[0-9.]+/)
 
     case versions
     when 'all'
@@ -44,7 +45,8 @@ test_namespace = namespace :test do
       Dir.chdir root do
         puts "Running tests against requirejs version: [#{version}]"
         system "npm install requirejs@#{version}"
-        cmd = "NODE_PATH=.:./spec:$NODE_PATH ./node_modules/.bin/mocha --compilers coffee:coffee-script --globals 'define,requirejsVars' --reporter spec #{debug} ./spec/requirejs.spec.coffee"
+        cmd = "node_modules/.bin/mocha --compilers coffee:coffee-script --globals 'define,requirejsVars' --reporter spec #{debug} ./spec/requirejs.spec.coffee"
+
         if isDebug?()
           system cmd
         else

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ task :build do
   system("cd #{root} && bundle exec coffee --compile --output . src/isolate.coffee")
   system("cd #{root} && bundle exec coffee --compile --output ./node_modules src/isolate.coffee")
   system("cd #{root} && bundle exec coffee --compile spec")
+  system("cd #{root} && bundle exec coffee --compile --output ./node_modules/commonjs_specific spec/modules_for_testing/commonjs")
 end
 
 test_namespace = namespace :test do
@@ -14,7 +15,7 @@ test_namespace = namespace :test do
   task :commonjs => :build do
     debug = isDebug?() ? ' debug' : ''
     Dir.chdir root do
-      system "NODE_PATH=.:./spec:./spec/modules_for_testing/commonjs:$NODE_PATH ./node_modules/.bin/mocha --compilers coffee:coffee-script --reporter spec #{debug} ./spec/commonjs.spec.coffee"
+      system "./node_modules/.bin/mocha --compilers coffee:coffee-script --reporter spec #{debug} ./spec/commonjs.spec.coffee"
     end
   end
 
@@ -70,6 +71,8 @@ task :clean do
   Dir.chdir root do
     FileUtils.rm(FileList['*.js'])
     FileUtils.rm(FileList['spec/**/*.js'])
+    FileUtils.rm(FileList['node_modules/*.js'])
+    FileUtils.rm(FileList['node_modules/commonjs_specific/*.js'])
   end
 end
 

--- a/Readme.md
+++ b/Readme.md
@@ -175,6 +175,13 @@ Isolate
   .map(/.*_view/, (options)-> {})
 ```
 or
+```coffeescript
+Isolate
+  .map('some/module', 'some/calling/module', {})
+  .map('/.*_controller$/', '/.*_view$/', (options)-> {})
+  .map(/.*_view/, /.*_module/, (options)-> {})
+```
+or
 
 ```coffeescript
 Isolate
@@ -188,7 +195,7 @@ for any given _matcher_ (See the _passthru_ section above for details
 on matchers).
 
 This option expects to be provided a matcher and either a standin
-instance to inject, or a _factory_ (see `map.asFactory` below). As
+instance to inject, or a _factory_ (see `map.asFactory` below). It is also possible to map a standin for a requesting module that is only applied from a specific calling module or matcher, in which case, a standing specified only for a specified calling module will supersede a generic standin in cases where it is valid to apply it. As
 syntactic sugar, you can also pass an object map of matcher: standin
 pairs too (second example above)
 
@@ -249,6 +256,18 @@ Isolate
       (options)-> {}
 ```
 or
+```coffeescript
+Isolate
+  .mapAsFactory 'some/module','some/calling/module',
+    (actual, module_path, requesting_module_path)-> {}
+  .mapAsFactory '/.*_controller$/','/calling/.*_view$/',
+    (actual, module_path, requesting_module_path)->
+      (options)-> {}
+  .mapAsFactory /.*_view/,/calling/.*_module/
+    (actual, module_path, requesting_module_path)->
+      (options)-> {}
+```
+or
 
 ```coffeescript
 Isolate
@@ -261,7 +280,7 @@ Isolate
 ```
 `mapAsFactory` allows you to provide a dynamically generated standin implementation
 to inject with the possibility to customize the standin to the requested
-module details. `mapAsFactory` follows the same _matcher_ rules described in the
+module details. It is also possible to specify a factory that only applies to the requested module when called from a specified module (or matcher), in which case, a standing specified only for a specified calling module will supersede a generic standin in cases where it is valid to apply it. `mapAsFactory` follows the same _matcher_ rules described in the
 _passthru_ section above.
 
 This option expects to be provided a matcher and a function which

--- a/spec/commonjs.spec.coffee
+++ b/spec/commonjs.spec.coffee
@@ -7,12 +7,12 @@ describe "Using node's require", ->
     module.constructor._cache = {}
     isolate.reset()
 
-  require('all_behaviours')
+  require('./all_behaviours')
     .ensure_all_behaviours isolate, (module_name, fun)->
       isolationContext = isolate
       if(arguments.length > 2)
         isolationContext = arguments[0]
         module_name = arguments[1]
         fun = arguments[2]
-      mod = isolationContext.require module_name
+      mod = isolationContext.require "./commonjs_specific/"+module_name
       fun mod

--- a/spec/requirejs.spec.coffee
+++ b/spec/requirejs.spec.coffee
@@ -28,7 +28,7 @@ runTests = (isolate)->
       undef _module for _module of mainCtx.defined
       isolate.reset()
 
-    require('all_behaviours')
+    require(path.join __dirname, "all_behaviours")
       .ensure_all_behaviours isolate, moduleFactory
 
     describe 'Handling requirejs plugins', ->


### PR DESCRIPTION
Firstly thanks for doing this project, I was laying the groundwork to do something exactly the same when I found it!

Secondly this is my first attempt at trying to collaborate on github so apologies if I'm not doing things wrong / not observing proper conventions

I have updated my fork of Isolate so it can be used to help me mock out my requirejs project in the same style as I'm used to in other projects. I always create mocks that are specific to each module under test, and it makes sense to define those mocks in the same file that the test is defined.

As it was, I couldn't do this elegantly with the head version of isolate because I had to define mocking behaviour for each mocked module in a single factory mapping (and put switch logic in their if I wanted different mocking behaviour for each module under test). To address this I extended the 'map' and 'mapAsFactory' methods so the factory / object can be mapped to be valid against a requested module AND a requesting module (or a matcher pattern). This allows developers to define a set of mappings specific to the module being tested at the top of the mocha test definition file.

A mapping that is for a specific calling module is used in preference to a mapping defined generally for a requested module, regardless of when each are defined, but otherwise they follow the existing 'use most recently defined' precedence logic.

I haven't added this functionality to the 'mapType' method, wasn't sure it was useful but can do so. There is no support for the new kind of mapping using the 'mapping hash' interface because I couldn't see a logical or elegant way of extending the existing convention to support it.

The extensions are unit tested & the readme has been updated.

In the process of adding unit tests I found that the existing test project I found it didn't work with Windows and newer node/npm versions so updated the rakefile & test files to remove Unix / Linux specific bash commands and use node_modules rather than updating NODE_PATH (which would require separate code for Windows & Linux to work and seemed flaky on my Windows tests anyway). I regression tested these changes on Ubuntu 12.04 using latest node/npm/ruby versions.

The functionality updates and compatibility changes are independent of each other, so if only one or the other are needed I can seperate them out.

Thanks

Steve
